### PR TITLE
Allows workspaces with hoisted packages

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -11,9 +11,11 @@ const resolveDependencies = require("../lib/resolveDependencies");
 const rootDir = process.cwd();
 const args = mri(process.argv.slice(2), {
   default: {
-    "build-dir": "_build"
+    "build-dir": "_build",
+    "build": true,
   },
-  string: ["build-dir", "output"]
+  string: ["build-dir", "output"],
+  boolean: ["build"],
 });
 
 const [folder] = args._;
@@ -64,7 +66,7 @@ const main = async () => {
   ensureDirSync(resolve(rootDir, pkgDir, "node_modules"));
 
   // build
-  if (pkg.scripts && pkg.scripts.build) {
+  if (args["build"] && pkg.scripts && pkg.scripts.build) {
     try {
       execSync("yarn build", { cwd: buildDir });
     } catch (buildError) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -76,12 +76,13 @@ const main = async () => {
   }
 
   // resolve dependencies
-  const deps = await resolveDependencies(pkg.dependencies, localModules);
+  const deps = await resolveDependencies(pkg.dependencies, localModules, [resolve("node_modules"), resolve(rootDir, pkgDir, "node_modules")]);
 
   // copy dependencies to node_modules
   deps
     .filter((value, index, self) => self.indexOf(value) === index)
     .map(dep => {
+      console.log(dep)
       const versionIndex = dep.lastIndexOf("@");
       const dirName = versionIndex <= 0 ? dep : dep.substr(0, versionIndex);
       const dir = resolve(rootDir, "node_modules", dirName);

--- a/lib/resolveDependencies.js
+++ b/lib/resolveDependencies.js
@@ -4,7 +4,6 @@ const fs = require("fs");
 config({ development: false, optional: false })
 
 const resolveDependencies = async (dependencies, localPkgs = [], localRepositories = []) => {
-  console.log(localRepositories)
   const deps = []
 
   for (const dep in dependencies) {

--- a/lib/resolveDependencies.js
+++ b/lib/resolveDependencies.js
@@ -1,7 +1,10 @@
 const { ls, config } = require('npm-remote-ls')
-config({development: false, optional: false})
+const path = require("path");
+const fs = require("fs");
+config({ development: false, optional: false })
 
-const resolveDependencies = async (dependencies, localPkgs = []) => {
+const resolveDependencies = async (dependencies, localPkgs = [], localRepositories = []) => {
+  console.log(localRepositories)
   const deps = []
 
   for (const dep in dependencies) {
@@ -9,12 +12,15 @@ const resolveDependencies = async (dependencies, localPkgs = []) => {
 
     if (localPkg) {
       deps.push(dep)
-      deps.push(...(await resolveDependencies(localPkg.dependencies, localPkgs)))
+      deps.push(...(await resolveDependencies(localPkg.dependencies, localPkgs, localRepositories)))
     } else {
-      const moduleDeps = await new Promise(resolve =>
+      const localDepPath = localRepositories.map(localRepo => path.join(localRepo, dep, "package.json")).find(localDepPath => fs.existsSync(localDepPath));
+
+      const moduleDeps = localDepPath ? Object.keys(require(localDepPath).dependencies || {}) : await new Promise(resolve =>
         ls(dep, dependencies[dep], true, obj => resolve(obj))
       )
-      deps.push(...moduleDeps)
+
+      deps.push(...(moduleDeps || []))
     }
   }
 


### PR DESCRIPTION
Hi!

In my environment I use the no-hoisting mechanism for yarn's workspaces, i.e. the `workspaces` key in `package.json` looks as follows:

```json
"workspaces": {
  "nohoist": [],
  "packages": []
```

This PR implements the acceptance of this pattern.